### PR TITLE
Game manager spawn player

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -299,6 +299,37 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &726604752
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 726604753}
+  m_Layer: 0
+  m_Name: PlayerSpawnLocation
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &726604753
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 726604752}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.103391714, y: -3.74, z: 0.63500416}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1382250503
 GameObject:
   m_ObjectHideFlags: 0
@@ -328,6 +359,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7d329c386cea3c34bbc62a598604dcc4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  PlayerSpawnLocation: {fileID: 726604753}
+  PlayerPrefab: {fileID: 0}
 --- !u!4 &1382250505
 Transform:
   m_ObjectHideFlags: 0
@@ -350,3 +383,4 @@ SceneRoots:
   - {fileID: 519420032}
   - {fileID: 518604842}
   - {fileID: 1382250505}
+  - {fileID: 726604753}

--- a/Assets/_Scripts/Managers/GameManager.cs
+++ b/Assets/_Scripts/Managers/GameManager.cs
@@ -4,6 +4,10 @@ using UnityEngine;
 
 public class GameManager : Singleton<GameManager>
 {
+    // Player spawn location and Player prefab
+    [SerializeField] Transform PlayerSpawnLocation;
+    [SerializeField] GameObject PlayerPrefab;
+
     private int _score;
     public int Score => _score;
 
@@ -15,7 +19,6 @@ public class GameManager : Singleton<GameManager>
         set { _lives = value; }
     }
 
-
     // Add score to be called when enemies are destroyed.
     public int AddToScore(int amountToAdd)
     {
@@ -26,14 +29,22 @@ public class GameManager : Singleton<GameManager>
     // Spawns a new player object at given location.
     public void SpawnPlayer(Transform location)
     {
-
+        Instantiate(location, PlayerPrefab.transform.position, Quaternion.identity);
     }
-
     
     // Start is called before the first frame update
     protected override void Start()
     {
         base.Start();
+
+        if (PlayerSpawnLocation != null && PlayerPrefab != null)
+        {
+            SpawnPlayer(PlayerSpawnLocation);
+        }
+        else
+        {
+            Debug.LogWarning("No player spawn location set in GameManager");
+        }
     }
 
     // Update is called once per frame

--- a/Assets/_Scripts/Managers/GameManager.cs
+++ b/Assets/_Scripts/Managers/GameManager.cs
@@ -29,7 +29,7 @@ public class GameManager : Singleton<GameManager>
     // Spawns a new player object at given location.
     public void SpawnPlayer(Transform location)
     {
-        Instantiate(location, PlayerPrefab.transform.position, Quaternion.identity);
+        Instantiate(PlayerPrefab, location.transform.position, Quaternion.identity);
     }
     
     // Start is called before the first frame update


### PR DESCRIPTION
Exposes 2 new fields in the GameManager to the Unity Editor:
- Player Spawn Location
  - Created an empty object as a temporary player spawn location. Once we layout the scene will likely need to adjust the PlayerSpawnLocation's transform position.
- Player Prefab
  - The player prefab is required in order to spawn a player. Once sprite assets are finalized and the player object is created it should be dropped into this field in Unity.