### PR TITLE
Hook into EnemyManager::Restart via CanvasManager events and GameManager call

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -2183,10 +2183,14 @@ MonoBehaviour:
   totalEnemies: 36
   minEnemiesPerSquad: 4
   maxEnemiesPerSquad: 8
-  minTimeBetweenSquads: 10
-  maxTimeBetweenSquads: 20
-  enemySpawnInfos: []
-  enemySpawnLocations: []
+  minTimeBetweenSquads: 4
+  maxTimeBetweenSquads: 7
+  enemySpawnInfos:
+  - {fileID: 11400000, guid: 1ef9ff271578bec438186982c8dadd11, type: 2}
+  - {fileID: 11400000, guid: 08f6d86ac6a644842812e9acc128c568, type: 2}
+  - {fileID: 11400000, guid: 4437d55dd4cd6bf41bbbcdcabcf4c775, type: 2}
+  enemySpawnLocations:
+  - {fileID: 732154223}
 --- !u!1 &1693131580
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/_Scripts/Enemy/EnemyManager.cs
+++ b/Assets/_Scripts/Enemy/EnemyManager.cs
@@ -37,14 +37,17 @@ public class EnemyManager : SingletonInScene<EnemyManager>
     // Flag to indicate if the enemy manager is currently spawning enemies
     private bool _isSpawning = false;
 
-    // Start is called before the first frame update
-    protected override void Start()
+    // Awake is called when the script instance is being loaded
+    protected override void Awake()
     {
         if (totalEnemies == 0)
             Debug.LogError("[EnemyManager] Total number of enemies to spawn is set to 0.");
 
         if (minEnemiesPerSquad == 0 || maxEnemiesPerSquad == 0 || maxEnemiesPerSquad > totalEnemies)
             Debug.LogError("[EnemyManager] Min or max number of enemies per squad is set to invalid value.");
+
+        if (enemySpawnInfos.Length == 0)
+            Debug.LogError("[EnemyManager] No enemy spawn infos set.");
 
         if (enemySpawnLocations.Length == 0)
             Debug.LogError("[EnemyManager] No enemy spawn locations set.");
@@ -66,6 +69,10 @@ public class EnemyManager : SingletonInScene<EnemyManager>
 
         if (distributionSum != totalEnemies)
             Debug.LogError("[EnemyManager] Enemy type distribution does not match total number of enemies to spawn.");
+
+        // Subscribe to CanvasManager events
+        CanvasManager.Instance.GamePaused += () => _isSpawning = false; // Pause the enemy manager
+        CanvasManager.Instance.GameUnpaused += () => _isSpawning = true; // Unpause the enemy manager
     }
 
     // Restart resets the enemy manager to its initial state
@@ -80,7 +87,7 @@ public class EnemyManager : SingletonInScene<EnemyManager>
 
         // Reset fields
         _timeSinceLastSquadSpawned = 0f;
-        _isSpawning = false;
+        _isSpawning = true;
 
         // Reset statistics
         _enemiesSpawned = 0;
@@ -171,13 +178,7 @@ public class EnemyManager : SingletonInScene<EnemyManager>
         return false;
     }
 
-    public void StartSpawningEnemies()
-    {
-        Debug.Log("ZA - StartSpawningEnemies");
-        _isSpawning = true;
-    }
-
-    public void Update()
+    protected override void Update()
     {
         // Trigger the coroutine to spawn a squad of enemies if we have not reached the total number of enemies to spawn
         // and an interval has passed since the last squad was spawned.

--- a/Assets/_Scripts/Enemy/EnemySpawnInfo.cs
+++ b/Assets/_Scripts/Enemy/EnemySpawnInfo.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 [CreateAssetMenu(fileName = "EnemySpawnInfo", menuName = "Enemy/EnemySpawnInfo")]

--- a/Assets/_Scripts/Helpers/Singleton.cs
+++ b/Assets/_Scripts/Helpers/Singleton.cs
@@ -1,6 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEditor.SearchService;
 using UnityEngine;
 
 [DefaultExecutionOrder(-1)]
@@ -51,7 +48,7 @@ public abstract class Singleton<T> : MonoBehaviour where T : Component
     }
 
     // Update is called once per frame
-    void Update()
+    protected virtual void Update()
     {
         
     }

--- a/Assets/_Scripts/Helpers/SingletonInScene.cs
+++ b/Assets/_Scripts/Helpers/SingletonInScene.cs
@@ -1,6 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
-using UnityEditor.SearchService;
 using UnityEngine;
 
 // This class is used to create a singleton that is destroyed when the scene changes.
@@ -38,7 +35,7 @@ public abstract class SingletonInScene<T> : MonoBehaviour where T : Component
             return;
         }
 
-        Destroy(gameObject);    
+        Destroy(gameObject);
     }
 
     // Start is called before the first frame update
@@ -48,7 +45,7 @@ public abstract class SingletonInScene<T> : MonoBehaviour where T : Component
     }
 
     // Update is called once per frame
-    void Update()
+    protected virtual void Update()
     {
         
     }

--- a/Assets/_Scripts/Managers/GameManager.cs
+++ b/Assets/_Scripts/Managers/GameManager.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -97,12 +93,7 @@ public class GameManager : Singleton<GameManager>
             Debug.LogWarning("No player spawn location set in GameManager");
         }
 
-        // Start spawning enemies
-        // TODO: ZA - Decide when this should actually happen
-        EnemyManager.Instance.StartSpawningEnemies();
-
-        Debug.Log("Start current number of lives" + Lives.ToString());
-        //CanvasManager.Instance.UpdateLifeImage(Lives);
+        RestartGame();
     }
 
     // When called in canvas manager it changes the scene. 
@@ -116,12 +107,13 @@ public class GameManager : Singleton<GameManager>
     {
         _score = 0;
         Lives = 2;
+
         CanvasManager.Instance.UpdateLifeImage(Lives);
-        // will also need to restart the enemy script. 
+        EnemyManager.Instance.Restart();
     }
 
     //Added to test game over menu. 
-    private void Update()
+    protected override void Update()
     {
         if (Input.GetKeyDown(KeyCode.B))
         {
@@ -141,7 +133,6 @@ public class GameManager : Singleton<GameManager>
     private void OnAllEnemiesKilled()
     {
         // TODO: ZA - Replace with a win screen or level progression
-        Debug.Log("ZA - All enemies killed. Game over.");
         GameOver();
     }
 }


### PR DESCRIPTION
Work associated with actually hooking into the new `EnemyManager::Restart` method to reset the `EnemyManager` and essentially restart the level.

### Changes:
#### `CanvasManager`
- New `GamePaused` event that is raised when the game is paused
- New `GameUnpaused` event that is raised when the game is unpaused
- Fixed some issues with changing the scene where a new singleton instance will accidentally be created

#### `EnemyManager`
- Listen to `GamePaused` event and pause all enemy spawning
- Listen to `GameUnpaused` event and resume all enemy spawning
- Fix flag that stops spawning on restart

#### `GameManager`
- Call `EnemyManager::Restart` on `Start` and `RestartGame`

#### Helper classes
- Make sure `Update` method is virtual so that it can be correctly overridden in inheriting classes

and some formatting cleanup
