### PR TITLE
Mark-WinScreen.

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -1309,9 +1309,11 @@ MonoBehaviour:
   PauseQuitButton: {fileID: 1693131582}
   MainMenu: {fileID: 0}
   PauseMenu: {fileID: 1467985076}
-  GameOverMenu: {fileID: 1229614314}
+  EndGameMenu: {fileID: 1229614314}
   ScoreText: {fileID: 406210565}
   HighScoreText: {fileID: 150712129}
+  GameOverText: {fileID: 1285238722}
+  WinText: {fileID: 1176725870}
   LifeImages:
   - {fileID: 421126319}
   - {fileID: 337521723}
@@ -1423,6 +1425,140 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
+--- !u!1 &1176725869
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1176725872}
+  - component: {fileID: 1176725871}
+  - component: {fileID: 1176725870}
+  m_Layer: 5
+  m_Name: WinGameText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1176725870
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1176725869}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Winner
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: d15c0fc102041404d88dd0e8d442c27d, type: 2}
+  m_sharedMaterial: {fileID: 6673418298010327092, guid: d15c0fc102041404d88dd0e8d442c27d, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 44
+  m_fontSizeBase: 44
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1176725871
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1176725869}
+  m_CullTransparentMesh: 1
+--- !u!224 &1176725872
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1176725869}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1229614315}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 140}
+  m_SizeDelta: {x: 265, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1229614314
 GameObject:
   m_ObjectHideFlags: 0
@@ -1433,7 +1569,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1229614315}
   m_Layer: 5
-  m_Name: GameOver
+  m_Name: EndGame
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1454,13 +1590,149 @@ RectTransform:
   - {fileID: 1514442868}
   - {fileID: 1901416471}
   - {fileID: 2081329888}
+  - {fileID: 1285238720}
+  - {fileID: 1176725872}
   m_Father: {fileID: 1033674776}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.000030518, y: 0}
+  m_AnchoredPosition: {x: 0, y: -80}
   m_SizeDelta: {x: 726.2, y: 290.4}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1285238719
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1285238720}
+  - component: {fileID: 1285238721}
+  - component: {fileID: 1285238722}
+  m_Layer: 5
+  m_Name: GameOverText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1285238720
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1285238719}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1229614315}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 140}
+  m_SizeDelta: {x: 400, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1285238721
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1285238719}
+  m_CullTransparentMesh: 1
+--- !u!114 &1285238722
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1285238719}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Game Over
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: d15c0fc102041404d88dd0e8d442c27d, type: 2}
+  m_sharedMaterial: {fileID: 6673418298010327092, guid: d15c0fc102041404d88dd0e8d442c27d, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 44
+  m_fontSizeBase: 44
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &1310811547
 GameObject:
   m_ObjectHideFlags: 0
@@ -1842,7 +2114,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.000011444, y: 73}
+  m_AnchoredPosition: {x: 0, y: 70}
   m_SizeDelta: {x: 269.8913, y: 31.4652}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1514442869
@@ -2416,7 +2688,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 25}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1901416472
@@ -2671,7 +2943,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: -72}
+  m_AnchoredPosition: {x: 0, y: -20}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2081329889

--- a/Assets/_Scripts/Managers/CanvasManager.cs
+++ b/Assets/_Scripts/Managers/CanvasManager.cs
@@ -23,11 +23,15 @@ public class CanvasManager : SingletonInScene<CanvasManager>
     [Header("Menus")]
     public GameObject MainMenu;
     public GameObject PauseMenu;
-    public GameObject GameOverMenu;
+    public GameObject EndGameMenu;
+   
 
     [Header("Text")]
     public TMP_Text ScoreText;
     public TMP_Text HighScoreText;
+    public TMP_Text GameOverText;
+    public TMP_Text WinText;
+   
 
     [Header("Image")]
     public Image[] LifeImages;
@@ -40,6 +44,9 @@ public class CanvasManager : SingletonInScene<CanvasManager>
             // Load game scene
             // Note: Need to explicitly load the scene as we don't want to start a new game instance in the current title scene
             StartButton.onClick.AddListener(() => SceneManager.LoadSceneAsync("Game"));
+
+            // This needs to be here so that when the game ends and the player returns to the main menu, then presses start again, the game is set back to the beginning. 
+            StartButton.onClick.AddListener(() => GameManager.Instance.RestartGame());
         }
 
         if (GameOverQuitButton || PauseQuitButton)
@@ -53,7 +60,7 @@ public class CanvasManager : SingletonInScene<CanvasManager>
 
         if (PlayAgainButton)
         {
-            PlayAgainButton.onClick.AddListener(() => SetMenus(null, GameOverMenu));
+            PlayAgainButton.onClick.AddListener(() => SetMenus(null, EndGameMenu));
             PlayAgainButton.onClick.AddListener(() => GameManager.Instance.RestartGame());
         }
 
@@ -117,8 +124,18 @@ public class CanvasManager : SingletonInScene<CanvasManager>
 
         if (GameManager.Instance.Lives == 0)
         {
-            GameOverMenu.SetActive(true);
+            EndGameMenu.SetActive(true);
+            WinText.enabled = false;
+            GameOverText.enabled = true;
         }
+
+        //Used to test the the text is setting properly, delete when no longer needed. 
+        //if(GameManager.Instance.Score == 20)
+        //{
+        //    EndGameMenu.SetActive(true);
+        //    GameOverText.enabled = false;
+        //    WinText.enabled = true;
+        //}
 
         if (ScoreText)
         {
@@ -131,6 +148,14 @@ public class CanvasManager : SingletonInScene<CanvasManager>
             HighScoreText.text = GameManager.Instance.HighScore(GameManager.Instance.Score).ToString();
         }
     }
+
+    //Enables end game screen and displays the Winner text.
+    public void GameWon()
+    {
+        EndGameMenu.SetActive(true);
+        GameOverText.enabled = false;
+    }
+
 
     public void UpdateLifeImage(int lives)
     {

--- a/Assets/_Scripts/Managers/CanvasManager.cs
+++ b/Assets/_Scripts/Managers/CanvasManager.cs
@@ -120,22 +120,7 @@ public class CanvasManager : SingletonInScene<CanvasManager>
         else
         {
             Time.timeScale = 1;
-        }
-
-        if (GameManager.Instance.Lives == 0)
-        {
-            EndGameMenu.SetActive(true);
-            WinText.enabled = false;
-            GameOverText.enabled = true;
-        }
-
-        //Used to test the the text is setting properly, delete when no longer needed. 
-        //if(GameManager.Instance.Score == 20)
-        //{
-        //    EndGameMenu.SetActive(true);
-        //    GameOverText.enabled = false;
-        //    WinText.enabled = true;
-        //}
+        }       
 
         if (ScoreText)
         {
@@ -154,8 +139,15 @@ public class CanvasManager : SingletonInScene<CanvasManager>
     {
         EndGameMenu.SetActive(true);
         GameOverText.enabled = false;
+        WinText.enabled = true;
     }
 
+    public void GameOver()
+    {
+        EndGameMenu.SetActive(true);
+        WinText.enabled = false;
+        GameOverText.enabled = true;
+    }
 
     public void UpdateLifeImage(int lives)
     {

--- a/Assets/_Scripts/Managers/GameManager.cs
+++ b/Assets/_Scripts/Managers/GameManager.cs
@@ -130,8 +130,8 @@ public class GameManager : Singleton<GameManager>
 
     // Event handler for when all enemies are killed
     private void OnAllEnemiesKilled()
-    {
-        // TODO: ZA - Replace with a win screen or level progression
+    {        
+        CanvasManager.Instance.GameWon();
         GameOver();
     }
 }

--- a/Assets/_Scripts/Managers/GameManager.cs
+++ b/Assets/_Scripts/Managers/GameManager.cs
@@ -55,7 +55,7 @@ public class GameManager : Singleton<GameManager>
     public void GameOver()
     {
         // Function to be completed
-        
+        CanvasManager.Instance.GameOver();
         Debug.Log("GameOver");
     }
 


### PR DESCRIPTION
I changed the gameOverMenu to endGameMenu, and added two text boxes which display the appropriate text at the and of the game, if all enemy's are dead the win text displays, if all lives are lost the game over text displays. The win situation is stored in a function and called from the GameManager, this hasn't been tested yet. I also added a line to the start button to call reset() from the GameManager, because if the player lost or won, then went to the main menu, pressed the start button again to restart the game, the game didn't reset, it just displayed the previous game's end state. If you want to do this a different way let me know, I mainly added it to test what I had done, and for this it works fine. 